### PR TITLE
Adding PATCH HTTP method

### DIFF
--- a/Shared/Networking/HTTPMethod.swift
+++ b/Shared/Networking/HTTPMethod.swift
@@ -9,6 +9,7 @@ public enum HTTPMethod: String {
     case get = "GET"
     case put = "PUT"
     case post = "POST"
+    case patch = "PATCH"
     case delete = "DELETE"
     case head = "HEAD"
     case options = "OPTIONS"


### PR DESCRIPTION
This PR adds the [`PATCH`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH) HTTP method to the HTTPMethod enum.