### PR TITLE
Adding collection safe subscript

### DIFF
--- a/Einstein.xcodeproj/project.pbxproj
+++ b/Einstein.xcodeproj/project.pbxproj
@@ -101,6 +101,10 @@
 		638360902282428900C3A1E7 /* DeepLinkable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638360662282341300C3A1E7 /* DeepLinkable.swift */; };
 		638360942282428E00C3A1E7 /* Instantiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63836062228224A800C3A1E7 /* Instantiable.swift */; };
 		6383609A22837D6100C3A1E7 /* UIAlertController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6383609922837D6100C3A1E7 /* UIAlertController+Extension.swift */; };
+		B5DBBE1D22A042C400D696C1 /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DBBE1C22A042C400D696C1 /* Collection+Extension.swift */; };
+		B5DBBE1E22A042CB00D696C1 /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DBBE1C22A042C400D696C1 /* Collection+Extension.swift */; };
+		B5DBBE1F22A042CC00D696C1 /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DBBE1C22A042C400D696C1 /* Collection+Extension.swift */; };
+		B5DBBE2022A042CC00D696C1 /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DBBE1C22A042C400D696C1 /* Collection+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -143,6 +147,7 @@
 		638360852282387200C3A1E7 /* ReachabilityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReachabilityManager.swift; sourceTree = "<group>"; };
 		638360892282405200C3A1E7 /* ReachabilityManagerListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReachabilityManagerListener.swift; sourceTree = "<group>"; };
 		6383609922837D6100C3A1E7 /* UIAlertController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extension.swift"; sourceTree = "<group>"; };
+		B5DBBE1C22A042C400D696C1 /* Collection+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -285,6 +290,7 @@
 				63836062228224A800C3A1E7 /* Instantiable.swift */,
 				6383609922837D6100C3A1E7 /* UIAlertController+Extension.swift */,
 				634B039F228B404800EB7796 /* DispatchQueue+Extension.swift */,
+				B5DBBE1C22A042C400D696C1 /* Collection+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -536,6 +542,7 @@
 				6304466D227CDA5600A29319 /* NSManagedObjectConvertible.swift in Sources */,
 				63044664227BB63200A29319 /* HTTPMethod.swift in Sources */,
 				63044661227BB63200A29319 /* HTTPHeader.swift in Sources */,
+				B5DBBE1D22A042C400D696C1 /* Collection+Extension.swift in Sources */,
 				630C704E228DE7CC00AA54DE /* JSONSerialization+Extension.swift in Sources */,
 				633F32E62295E8D2004A2795 /* Configuration.swift in Sources */,
 				63836063228224A800C3A1E7 /* Instantiable.swift in Sources */,
@@ -570,6 +577,7 @@
 				634B03A4228B41E600EB7796 /* StringKey.swift in Sources */,
 				63044632227BB62300A29319 /* MockURLProtocol.swift in Sources */,
 				63044635227BB62300A29319 /* URLSession+Networking.swift in Sources */,
+				B5DBBE1E22A042CB00D696C1 /* Collection+Extension.swift in Sources */,
 				63422336228E661100F9CA92 /* EmptyAPIResponse.swift in Sources */,
 				633F32E72295E8D2004A2795 /* Configuration.swift in Sources */,
 				630C7064228DFC8100AA54DE /* JSONSerialization+Extension.swift in Sources */,
@@ -600,6 +608,7 @@
 				63044636227BB62300A29319 /* URLSession+Networking.swift in Sources */,
 				6304465A227BB63200A29319 /* APIRequest.swift in Sources */,
 				638360942282428E00C3A1E7 /* Instantiable.swift in Sources */,
+				B5DBBE1F22A042CC00D696C1 /* Collection+Extension.swift in Sources */,
 				634B03A7228B41F900EB7796 /* DispatchQueue+Extension.swift in Sources */,
 				63044645227BB63200A29319 /* GrioError.swift in Sources */,
 				6301582722960405007BA3F1 /* ConfigurationKey.swift in Sources */,
@@ -618,6 +627,7 @@
 				630C7076228DFCAB00AA54DE /* URLSession+Networking.swift in Sources */,
 				63422334228E661000F9CA92 /* EmptyAPIResponse.swift in Sources */,
 				630C706C228DFC9300AA54DE /* FeatureFlag.swift in Sources */,
+				B5DBBE2022A042CC00D696C1 /* Collection+Extension.swift in Sources */,
 				633F32E92295E8D2004A2795 /* Configuration.swift in Sources */,
 				630C706E228DFC9900AA54DE /* APIRequest.swift in Sources */,
 				630C7069228DFC8F00AA54DE /* DispatchQueue+Extension.swift in Sources */,

--- a/Shared/Extensions/Collection+Extension.swift
+++ b/Shared/Extensions/Collection+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  Collection+Extension.swift
+//  Einstein iOS
+//
+
+import Foundation
+
+extension Collection {
+    subscript(safe index: Index) -> Element? {
+        guard indices.contains(index) else { return nil }
+
+        return self[index]
+    }
+}


### PR DESCRIPTION
This PR adds a subscript to safely get items from a collection, returning `nil` if the item doesn't exist in the collection.

Example:

```swift
let array: [Int] = [1, 2, 3, 4, 5]

let firstItem: Int? = array[safe: 0] // 1
let invalidItem: Int? = array[safe: 100] // nil
```

One question that might want to be discussed is if `safe` is truly the best naming for this method. I also considered using `safely` but neither seems truly the best option. Would be open to ideas as to how to improve the naming of that if we think it'd be a good idea.